### PR TITLE
Timezone flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Use the help option to learn all the command line options and modify its executi
 Usage of ./rocketchat-google-calendar:
   -calendars string
         List of calendar IDs, separated by commas. (default "primary")
+  -timezone string
+        Specify the timezone the start and end dates should be in (default: "America/New_York")
   -credentials string
         Enter path to the credentials file. (default "credentials.json")
   -eventin string

--- a/main.go
+++ b/main.go
@@ -151,7 +151,7 @@ func main() {
 	flag.StringVar(&waitFor, "waitfor", "5m", "Time to wait before attempting a POST to Rocket.Chat webhook.")
 	flag.StringVar(&eventInMax, "eventin", "30m", "The upper limit of upcoming event start time. Lower bound is the moment of API access.")
 	flag.StringVar(&calendarIds, "calendars", "primary", "List of calendar IDs, separated by commas.")
-	flag.StringVar(&timeLoc, "timezone", "America/New_York", "Specify a timezone.")
+	flag.StringVar(&timeLoc, "timezone", "UTC", "Specify a timezone.")
 	flag.Parse()
 
 	if webhookUrl == "" {
@@ -171,16 +171,14 @@ func main() {
 		log.Fatalf("Failed to capture client: %v", err)
 	}
 
-	location, err := time.LoadLocation(timeLoc)
-
-	if err != nil {
+	if _, err = time.LoadLocation(timeLoc); err != nil {
 		panic(err)
 	}
 
 	for {
 		<-ticker.C
 
-		events, err := getEvents(client, strings.Split(calendarIds, ","), duration, location.String())
+		events, err := getEvents(client, strings.Split(calendarIds, ","), duration, timeLoc)
 		if err != nil {
 			log.Fatalf("ERROR: %v", err)
 		}

--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func getEvents(client *http.Client, calendarIds []string, dueInMinutes time.Dura
 			TimeMax(now.Add(dueInMinutes).Format(time.RFC3339)).
 			MaxResults(10).
 			OrderBy("startTime").
-			TimeZone("UTC").
+			TimeZone(timeLoc).
 			Do()
 		if err != nil {
 			return nil, fmt.Errorf("unable to get list of events: %v", err)
@@ -140,6 +140,7 @@ func main() {
 		credentialsFile,
 		waitFor,
 		calendarIds,
+        timeLoc,
 		eventInMax string
 		duration time.Duration
 		err      error
@@ -150,6 +151,7 @@ func main() {
 	flag.StringVar(&waitFor, "waitfor", "5m", "Time to wait before attempting a POST to Rocket.Chat webhook.")
 	flag.StringVar(&eventInMax, "eventin", "30m", "The upper limit of upcoming event start time. Lower bound is the moment of API access.")
 	flag.StringVar(&calendarIds, "calendars", "primary", "List of calendar IDs, separated by commas.")
+    flag.StringVar(&timeLoc, "timezone", "America/New_York", "Specify a timezone.")
 	flag.Parse()
 
 	if webhookUrl == "" {
@@ -168,6 +170,10 @@ func main() {
 	if client, err = getClient(credentialsFile); err != nil {
 		log.Fatalf("Failed to capture client: %v", err)
 	}
+
+    if timeLoc, err = time.LoadLocation(timeLoc); err != nil {
+        log.Fatalf("Invalid Timezone Specification", err)
+    }
 
 	for {
 		<-ticker.C


### PR DESCRIPTION
Adding a flag that allows a user to customize the time zone in which the event is listed.  All events previously came through as UTC.  Default is changed to America/New_York, but can be anything in the standard format.